### PR TITLE
Add vscode dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+	"name": "Cockpit open frontend",
+
+	"context": "..",
+	"dockerFile": "../Dockerfile",
+
+	// Run the devolonetsvc on your host to see devices
+	"runArgs": [ "--net", "host" ],
+
+	// Run 'xhost +local:' on your host to enable showing the UI on the host system
+	"mounts": [ "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached" ],
+    "containerEnv": {
+        "DISPLAY": "unix:0"
+    },
+
+	"settings": { 
+		"terminal.integrated.shell.linux": null,
+		"[dart]": {
+			"editor.selectionHighlight": false,
+			"editor.suggest.snippetsPreventQuickSuggestions": false,
+			"editor.wordBasedSuggestions": false,
+		},
+	},
+
+	"extensions": [
+		"dart-code.flutter",
+		"localizely.flutter-intl"
+	],
+
+	"postCreateCommand": "flutter pub get",
+}


### PR DESCRIPTION
Microsoft Visual Studio code supports an easy start in development using devcontainer. They come will all the packages that I need to start development right away.

The devcontainer was developed and tested on Linux, other OS still need some love.

This devcontainer requires two things: you need to start the devolonetsvc on the host system to see devices and you need to run 'xhost +local:' if you want to see the UI while debugging.