### PR TITLE
Add vscode devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,31 @@
 {
-	"name": "Cockpit open frontend",
+    "name": "Cockpit open frontend",
 
-	"context": "..",
-	"dockerFile": "../Dockerfile",
+    "context": "..",
+    "dockerFile": "../Dockerfile",
 
-	// Run the devolonetsvc on your host to see devices
-	"runArgs": [ "--net", "host" ],
+    // Run the devolonetsvc on your host to see devices
+    "runArgs": [ "--net", "host" ],
 
-	// Run 'xhost +local:' on your host to enable showing the UI on the host system
-	"mounts": [ "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached" ],
+    // Run 'xhost +local:' on your host to enable showing the UI on the host system
+    "mounts": [ "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached" ],
     "containerEnv": {
         "DISPLAY": "unix:0"
     },
 
-	"settings": { 
-		"terminal.integrated.shell.linux": null,
-		"[dart]": {
-			"editor.selectionHighlight": false,
-			"editor.suggest.snippetsPreventQuickSuggestions": false,
-			"editor.wordBasedSuggestions": false,
-		},
-	},
+    "settings": { 
+        "terminal.integrated.shell.linux": null,
+        "[dart]": {
+            "editor.selectionHighlight": false,
+            "editor.suggest.snippetsPreventQuickSuggestions": false,
+            "editor.wordBasedSuggestions": false,
+        },
+    },
 
-	"extensions": [
-		"dart-code.flutter",
-		"localizely.flutter-intl"
-	],
+    "extensions": [
+        "dart-code.flutter",
+        "localizely.flutter-intl"
+    ],
 
-	"postCreateCommand": "flutter pub get",
+    "postCreateCommand": "flutter pub get",
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+	"name": "Cockpit open frontend",
+
+	"context": "..",
+	"dockerFile": "../Dockerfile",
+
+	// Run the devolonetsvc on your host to see devices
+	"runArgs": [ "--net", "host" ],
+
+	// Run 'xhost +local:' on your host to enable showing the UI on the host system
+	"mounts": [ "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached" ],
+    "containerEnv": {
+        "DISPLAY": "unix:0"
+    },
+
+	"settings": { 
+		"terminal.integrated.shell.linux": null,
+		"[dart]": {
+			"editor.selectionHighlight": false,
+			"editor.suggest.snippetsPreventQuickSuggestions": false,
+			"editor.wordBasedSuggestions": false,
+		},
+	},
+
+	"extensions": [
+		"dart-code.flutter",
+		"localizely.flutter-intl"
+	],
+
+	"postCreateCommand": "flutter pub get",
+}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ flutter run -d <platform>
 ```
 where platform is `windows`, `macos`, or `linux`.
 
-To build and run the app on programming IDEs, see instructions from Flutter for [Android Studio and IntelliJ,](https://flutter.dev/docs/development/tools/android-studio) and [Visual Studio Code.](https://flutter.dev/docs/development/tools/vs-code)
+To build and run the app on programming IDEs, see instructions from Flutter for [Android Studio and IntelliJ](https://flutter.dev/docs/development/tools/android-studio), and [Visual Studio Code](https://flutter.dev/docs/development/tools/vs-code). For Visual Studio Code and Linux users we provide a devcontainer which allows you to start [developing inside a container](https://code.visualstudio.com/docs/remote/containers). You then need the [devolo Cockpit application](https://www.devolo.de/support/downloads/download/devolo-cockpit) on your host system and you need to run `xhost +local:` if you want to see the UI while debugging.
 
 ## Building Releases
 


### PR DESCRIPTION
Microsoft Visual Studio code supports an easy start in development using devcontainer. They come will all the packages that I need to start development right away.

The devcontainer was developed and tested on Linux, other OS still need some love.

This devcontainer requires two things: you need to start the devolonetsvc on the host system to see devices and you need to run 'xhost +local:' if you want to see the UI while debugging.