### PR TITLE
Doc: Add note to readme about enabling flutter desktop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ It is written in [Flutter](https://flutter.dev) and supports all desktops: Windo
 ### Tips
 * To ensure Flutter is setup correctly, you can run the `$ flutter doctor` command in Terminal or Command Prompt.
 * To ensure that you have enabled desktop support for your device, run the `$ flutter devices` command in Terminal or Command Prompt.
+* For flutter, desktop support must be added separately for each platform. (see: https://docs.flutter.dev/desktop#set-up)
+  Foe example for Linux: flutter config --enable-linux-desktop
 
 ## Building and Running the App
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It is written in [Flutter](https://flutter.dev) and supports all desktops: Windo
 * To ensure Flutter is setup correctly, you can run the `$ flutter doctor` command in Terminal or Command Prompt.
 * To ensure that you have enabled desktop support for your device, run the `$ flutter devices` command in Terminal or Command Prompt.
 * For flutter, desktop support must be added separately for each platform. (see: https://docs.flutter.dev/desktop#set-up)
-  Foe example for Linux: flutter config --enable-linux-desktop
+  Foe example for Linux: `$ flutter config --enable-linux-desktop`
 
 ## Building and Running the App
 


### PR DESCRIPTION
As to help out flutter beginners, document the answer to issue #5 in the readme alongside the existing tips.