### PR TITLE
intl: EN: Remove plural s for "information"

### DIFF
--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -77,7 +77,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "chooseTheAppTheme":
             MessageLookupByLibrary.simpleMessage("Choose the app theme"),
         "cockpitSupportInformationBody": MessageLookupByLibrary.simpleMessage(
-            "The support informations have been created and are now available to you. Please select an action."),
+            "The support information have been created and are now available to you. Please select an action."),
         "cockpitSupportInformationTitle": MessageLookupByLibrary.simpleMessage(
             "devolo Cockpit support information"),
         "complete": MessageLookupByLibrary.simpleMessage("complete"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -77,7 +77,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "chooseTheAppTheme":
             MessageLookupByLibrary.simpleMessage("Choose the app theme"),
         "cockpitSupportInformationBody": MessageLookupByLibrary.simpleMessage(
-            "The support information have been created and are now available to you. Please select an action."),
+            "The support information has been created and is now available to you. Please select an action."),
         "cockpitSupportInformationTitle": MessageLookupByLibrary.simpleMessage(
             "devolo Cockpit support information"),
         "complete": MessageLookupByLibrary.simpleMessage("complete"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -23,10 +23,10 @@ class MessageLookup extends MessageLookupByLibrary {
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "LoadCockpitSupportInformationBody":
             MessageLookupByLibrary.simpleMessage(
-                "Support informations are getting generated"),
+                "Support information is getting generated"),
         "SendCockpitSupportInformationBody":
             MessageLookupByLibrary.simpleMessage(
-                "Support informations are sent to devolo"),
+                "Support information is sent to devolo"),
         "activateLEDs": MessageLookupByLibrary.simpleMessage("LEDs activated"),
         "activateLEDsFailedBody": MessageLookupByLibrary.simpleMessage(
             "An error occurred while modifying the LEDs!\nTry again later"),

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -99,9 +99,9 @@
   "pleaseEnterYourMailAddress": "Enter your email address",
   "contactInfo": "Contact information",
   "yourEmailAddress": "Your email address",
-  "LoadCockpitSupportInformationBody": "Support informations are getting generated",
-  "SendCockpitSupportInformationBody": "Support informations are sent to devolo",
-  "cockpitSupportInformationBody": "The support informations have been created and are now available to you. Please select an action.",
+  "LoadCockpitSupportInformationBody": "Support information is getting generated",
+  "SendCockpitSupportInformationBody": "Support information is sent to devolo",
+  "cockpitSupportInformationBody": "The support information have been created and are now available to you. Please select an action.",
   "emailIsInvalid": "E-mail is invalid",
 
   "@_OPTIMIZATION_DIALOG": {

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -101,7 +101,7 @@
   "yourEmailAddress": "Your email address",
   "LoadCockpitSupportInformationBody": "Support information is getting generated",
   "SendCockpitSupportInformationBody": "Support information is sent to devolo",
-  "cockpitSupportInformationBody": "The support information have been created and are now available to you. Please select an action.",
+  "cockpitSupportInformationBody": "The support information has been created and is now available to you. Please select an action.",
   "emailIsInvalid": "E-mail is invalid",
 
   "@_OPTIMIZATION_DIALOG": {


### PR DESCRIPTION
Hello Devolo team!

Usually the usage of the English word "information" is uncountable.

Me reading this message made me assume it was a translation mistake, the Wiktionary [1] entry lists it as _usually_ uncountable. 

With this PR I can only talk for myself, and perhaps if you have a translation team ask them what they say?

btw: many thanks for the recent updates, now I can run the application locally without any problems.

[1] https://en.wiktionary.org/wiki/information