### PR TITLE
Pubspec: Replace no longer supported git:// dependency usage for URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It is written in [Flutter](https://flutter.dev) and supports all desktops: Windo
 * To ensure that you have enabled desktop support for your device, run the `$ flutter devices` command in Terminal or Command Prompt.
 * For flutter, desktop support must be added separately for each platform. (see: https://docs.flutter.dev/desktop#set-up)
   For example for Linux: `$ flutter config --enable-linux-desktop`
+* If the error `Member not found: 'packageRoot'` is shown during startup, use `$ flutter pub upgrade` to upgrade the Flutter SDK cache. 
 
 ## Building and Running the App
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -697,7 +697,7 @@ packages:
       path: "plugins/window_size"
       ref: "7812516a5c1fc8ef379e244106953a2b534432b9"
       resolved-ref: "7812516a5c1fc8ef379e244106953a2b534432b9"
-      url: "git://github.com/google/flutter-desktop-embedding.git"
+      url: "https://github.com/google/flutter-desktop-embedding"
     source: git
     version: "0.1.0"
   xdg_directories:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   flutter_phoenix: ^1.0.0
   window_size:
     git:
-      url: git://github.com/google/flutter-desktop-embedding.git
+      url: https://github.com/google/flutter-desktop-embedding
       path: plugins/window_size
       ref: 7812516a5c1fc8ef379e244106953a2b534432b9
 


### PR DESCRIPTION
Fix the build on Linux by replacing the git:// prefix with https://.

Without this, the following error is shown:

```
➜  cockpit_open_frontend git:(develop) ✗ flutter pub upgrade
Resolving dependencies...
Git error. Command: `git fetch`
stdout: 
stderr: fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
exit code: 128
pub finished with exit code 69
➜  cockpit_open_frontend git:(develop) ✗ 
```

For further details, see this issue:

https://github.com/flutter/flutter/issues/96456

Lastly, this PR also suggest to document a workaround for another error, one which have happened to me after each flutter upgrade.

```
➜  cockpit_open_frontend git:(develop) ✗ flutter run -d linux
Downloading linux-x64/linux-x64-flutter-gtk tools...                3.1s
Downloading linux-x64-profile/linux-x64-flutter-gtk tools...      1,406ms
Downloading linux-x64-release/linux-x64-flutter-gtk tools...      1,083ms
Running "flutter pub get" in cockpit_open_frontend...              10.2s
Launching lib/main.dart on Linux in debug mode...
add_custom_command() missing VERBATIM or FLUTTER_TARGET_PLATFORM, updating.
ERROR: ../../.pub-cache/hosted/pub.dartlang.org/platform-3.0.0/lib/src/interface/local_platform.dart:46:19: Error: Member not found: 'packageRoot'.
ERROR:       io.Platform.packageRoot; // ignore: deprecated_member_use
ERROR:                   ^^^^^^^^^^^
Building Linux application...                                           
Exception: Build process failed
➜  cockpit_open_frontend git:(develop) ✗
```