### PR TITLE
Update "provider" dependency to v6

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -440,7 +440,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.3"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
   xml: ^5.1.1
-  provider: ^5.0.0 # previous: ^3.0.0
+  provider: ^6.0.0 # previous: ^5.0.0
   url_launcher: ^6.0.4 # previous: ^5.7.10
   flutter_svg: ^0.21.0+1 #^0.20.0-nullsafety.3
   open_file: ^3.2.1


### PR DESCRIPTION
Update "provider" dependency to v6.

This as to address the following build error:

```log
$ flutter build linux                  

💪 Building with sound null safety 💪

ERROR: ../../.pub-cache/hosted/pub.dartlang.org/provider-5.0.0/lib/src/inherited_provider.dart:391:26: Warning: Operand of null-aware operation '!' has type 'SchedulerBinding' which excludes null.
ERROR:  - 'SchedulerBinding' is from 'package:flutter/src/scheduler/binding.dart' ('/opt/flutter/packages/flutter/lib/src/scheduler/binding.dart').
ERROR:         SchedulerBinding.instance!.addPostFrameCallback((_) {
ERROR:                          ^
Building Linux application...             
```
